### PR TITLE
escape contents of code_inline code_block and fence

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,6 +1,7 @@
 'use strict';
 
 var jsx_inline = require('./lib/jsx_inline');
+var escape_code = require('./lib/escape_code');
 
 module.exports = function jsx_plugin(md) {
   md.set({ xhtmlOut: true });
@@ -73,6 +74,10 @@ module.exports = function jsx_plugin(md) {
       return paragraphTokensToRemove.indexOf(idx) === -1;
     });
   });
+
+  md.renderer.rules.fence = escape_code(md.renderer.rules.fence);
+  md.renderer.rules.code_inline = escape_code(md.renderer.rules.code_inline);
+  md.renderer.rules.code_block = escape_code(md.renderer.rules.code_block);
 
   md.renderer.rules['jsx_inline'] = function(tokens, idx) {
     // If the span is JSX, just pass the original source for the span

--- a/lib/escape_code.js
+++ b/lib/escape_code.js
@@ -4,6 +4,7 @@ module.exports = function escape_code(default_renderer) {
   return function escape_renderer(tokens, idx, options, env, slf) {
     tokens[idx].content = '{`' + tokens[idx].content.replace(/`/g, '\\\`') + '`}'
 
-    return default_renderer(tokens, idx, options, env, slf);
+    return default_renderer(tokens, idx, options, env, slf)
+      .replace(/class="/g, 'className="');
   };
 }

--- a/lib/escape_code.js
+++ b/lib/escape_code.js
@@ -1,0 +1,9 @@
+'use strict'
+
+module.exports = function escape_code(default_renderer) {
+  return function escape_renderer(tokens, idx, options, env, slf) {
+    tokens[idx].content = '{`' + tokens[idx].content.replace(/`/g, '\\\`') + '`}'
+
+    return default_renderer(tokens, idx, options, env, slf);
+  };
+}

--- a/test/fixtures/escaped_code.txt
+++ b/test/fixtures/escaped_code.txt
@@ -1,0 +1,29 @@
+---
+desc: code_inline code_block and fence
+---
+
+escaped content of code_inline
+.
+`alert('yay');`
+.
+<p><code>{`alert('yay');`}</code></p>
+.
+
+escaped content of code_block
+.
+    window.location = 'example.org';
+.
+<pre><code>{`window.location = 'example.org';
+`}</code></pre>
+.
+
+escaped content of fence
+.
+```jsx
+<MyComponent>{isEscaped(`?!`)}</MyComponent>
+```
+.
+<pre><code class="language-jsx">{`&lt;MyComponent&gt;{isEscaped(\`?!\`)}&lt;/MyComponent&gt;
+`}</code></pre>
+.
+

--- a/test/fixtures/escaped_code.txt
+++ b/test/fixtures/escaped_code.txt
@@ -23,7 +23,6 @@ escaped content of fence
 <MyComponent>{isEscaped(`?!`)}</MyComponent>
 ```
 .
-<pre><code class="language-jsx">{`&lt;MyComponent&gt;{isEscaped(\`?!\`)}&lt;/MyComponent&gt;
+<pre><code className="language-jsx">{`&lt;MyComponent&gt;{isEscaped(\`?!\`)}&lt;/MyComponent&gt;
 `}</code></pre>
 .
-

--- a/test/test.js
+++ b/test/test.js
@@ -12,4 +12,5 @@ describe('markdown-it-jsx', function() {
   test('basic.txt');
   test('inline.txt');
   test('block.txt');
+  test('escaped_code.txt');
 });


### PR DESCRIPTION
As described in https://github.com/osnr/markdown-it-jsx/issues/1#issuecomment-272962389

this converts

    ```js
    function() { alert('yay'); }
    ```

to

```jsx
<pre><code class="language-js">{`function() { alert('yay'); }
`}</code></pre>
```

So JSX parsers don't get confused with embedded documentation anymore.